### PR TITLE
Use `Packs.config.pack_paths` to validate CLI arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: false
+  TargetRubyVersion: 2.6
   Exclude:
     - vendor/bundle/**/**
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.2)
   packwerk!
-  pry (> 0.13)
+  pry
   pry-byebug
   rake
   rspec (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,12 +87,12 @@ GEM
       ast (~> 2.4.1)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pry (0.13.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.8.0)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
+      pry (~> 0.10)
     racc (1.6.1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
@@ -151,15 +151,7 @@ GEM
     sorbet (0.5.9962)
       sorbet-static (= 0.5.9962)
     sorbet-runtime (0.5.9976)
-    sorbet-static (0.5.9962-universal-darwin-14)
-    sorbet-static (0.5.9962-universal-darwin-15)
-    sorbet-static (0.5.9962-universal-darwin-16)
-    sorbet-static (0.5.9962-universal-darwin-17)
-    sorbet-static (0.5.9962-universal-darwin-18)
-    sorbet-static (0.5.9962-universal-darwin-19)
-    sorbet-static (0.5.9962-universal-darwin-20)
     sorbet-static (0.5.9962-universal-darwin-21)
-    sorbet-static (0.5.9962-x86_64-linux)
     spoom (1.1.11)
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
@@ -206,12 +198,12 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   bundler (~> 2.2)
   packwerk!
-  pry
+  pry (> 0.13)
   pry-byebug
   rake
   rspec (~> 3.0)
@@ -223,4 +215,4 @@ DEPENDENCIES
   use_packs!
 
 BUNDLED WITH
-   2.2.29
+   2.4.6

--- a/lib/use_packs.rb
+++ b/lib/use_packs.rb
@@ -25,11 +25,6 @@ require 'packs'
 module UsePacks
   extend T::Sig
 
-  PERMITTED_PACK_LOCATIONS = T.let(
-    Packs.config.pack_paths,
-    T::Array[String]
-  )
-
   sig { void }
   def self.start_interactive_mode!
     Private::InteractiveCli.start!

--- a/lib/use_packs.rb
+++ b/lib/use_packs.rb
@@ -20,15 +20,15 @@ require 'use_packs/code_ownership_post_processor'
 require 'use_packs/logging'
 require 'use_packs/configuration'
 require 'use_packs/cli'
+require 'packs'
 
 module UsePacks
   extend T::Sig
 
-  PERMITTED_PACK_LOCATIONS = T.let(%w[
-                                     gems
-                                     components
-                                     packs
-                                   ], T::Array[String])
+  PERMITTED_PACK_LOCATIONS = T.let(
+    Packs.config.pack_paths.flat_map { |glob| glob.scan(/\w|\//).join.squeeze("/") }.uniq,
+    T::Array[String]
+  )
 
   sig { void }
   def self.start_interactive_mode!

--- a/lib/use_packs.rb
+++ b/lib/use_packs.rb
@@ -26,7 +26,7 @@ module UsePacks
   extend T::Sig
 
   PERMITTED_PACK_LOCATIONS = T.let(
-    Packs.config.pack_paths.flat_map { |glob| glob.scan(/\w|\//).join.squeeze("/") }.uniq,
+    Packs.config.pack_paths,
     T::Array[String]
   )
 

--- a/lib/use_packs/invalid_pack_name_error.rb
+++ b/lib/use_packs/invalid_pack_name_error.rb
@@ -1,0 +1,42 @@
+
+module UsePacks
+  class InvalidPackNameError < StandardError
+    class << self
+      def configured_pack_locations
+        @configured_pack_locations ||= Packs.config.pack_paths
+      end
+
+      def permitted_pack_locations
+        return @permitted_pack_locations if defined?(@permitted_pack_locations)
+
+        if configured_pack_locations == %w[packs/* packs/*/*]
+          @permitted_pack_locations = %w[gems/* components/* packs/* packs/*/*]
+        else
+          @permitted_pack_locations = configured_pack_locations
+        end
+      end
+
+      def folders
+        @folders ||= permitted_pack_locations.map { _1.scan(/\w*/).join }.uniq.sort
+      end
+    end
+
+    DEFAULT_MESSAGE = <<~MSG.freeze
+      UsePacks supports packages in directories based on configuration set in packs.yml.
+
+      Currently permitted directories: \n\t#{folders.join("\n\t")}
+
+      Please make sure to pass in the name of the pack including the full
+      directory path, e.g. `#{folders.first}/my_pack`."
+    MSG
+
+    def initialize(msg = DEFAULT_MESSAGE)
+      super
+    end
+  end
+
+  PERMITTED_PACK_LOCATIONS = T.let(
+    InvalidPackNameError.permitted_pack_locations,
+    T::Array[String]
+  )
+end

--- a/lib/use_packs/private.rb
+++ b/lib/use_packs/private.rb
@@ -358,7 +358,7 @@ module UsePacks
       ).returns(ParsePackwerk::Package)
     end
     def self.create_pack_if_not_exists!(pack_name:, enforce_privacy:, enforce_dependencies:, team: nil)
-      if PERMITTED_PACK_LOCATIONS.none? { |permitted_location| pack_name.start_with?(permitted_location) }
+      if PERMITTED_PACK_LOCATIONS.none? { |permitted_location| pack_name.match?(permitted_location) }
         raise StandardError, "UsePacks only supports packages in the the following directories: #{PERMITTED_PACK_LOCATIONS.inspect}. Please make sure to pass in the name of the pack including the full directory path, e.g. `packs/my_pack`."
       end
 

--- a/lib/use_packs/private.rb
+++ b/lib/use_packs/private.rb
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'colorized_string'
 require 'sorbet-runtime'
 
+require 'use_packs/invalid_pack_name_error'
 require 'use_packs/private/file_move_operation'
 require 'use_packs/private/pack_relationship_analyzer'
 require 'use_packs/private/interactive_cli'
@@ -359,7 +360,7 @@ module UsePacks
     end
     def self.create_pack_if_not_exists!(pack_name:, enforce_privacy:, enforce_dependencies:, team: nil)
       if PERMITTED_PACK_LOCATIONS.none? { |permitted_location| pack_name.match?(permitted_location) }
-        raise StandardError, "UsePacks only supports packages in the the following directories: #{PERMITTED_PACK_LOCATIONS.inspect}. Please make sure to pass in the name of the pack including the full directory path, e.g. `packs/my_pack`."
+        raise UsePacks::InvalidPackNameError
       end
 
       existing_package = ParsePackwerk.all.find { |p| p.name == pack_name }


### PR DESCRIPTION
Previously, the list of valid paths was hard-coded. This allow the CLI to use the actual configuration of `packs` to validate against the actually constraints.