### PR TITLE
Allow skipping public dir creation when creating pack or moving files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.28)
+    packs (0.0.29)
       code_ownership (>= 1.33.0)
       packs-specification
       packwerk

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -56,23 +56,20 @@ module Packs
       pack_name: String,
       enforce_privacy: T::Boolean,
       enforce_dependencies: T.nilable(T::Boolean),
-      team: T.nilable(CodeTeams::Team),
-      skip_public: T.nilable(T::Boolean)
+      team: T.nilable(CodeTeams::Team)
     ).void
   end
   def self.create_pack!(
     pack_name:,
     enforce_privacy: true,
     enforce_dependencies: nil,
-    team: nil,
-    skip_public: false
+    team: nil
   )
     Private.create_pack!(
       pack_name: pack_name,
       enforce_privacy: enforce_privacy,
       enforce_dependencies: enforce_dependencies,
-      team: team,
-      skip_public: skip_public
+      team: team
     )
   end
 
@@ -80,15 +77,13 @@ module Packs
     params(
       pack_name: String,
       paths_relative_to_root: T::Array[String],
-      per_file_processors: T::Array[PerFileProcessorInterface],
-      skip_public: T.nilable(T::Boolean)
+      per_file_processors: T::Array[PerFileProcessorInterface]
     ).void
   end
   def self.move_to_pack!(
     pack_name:,
     paths_relative_to_root: [],
-    per_file_processors: [],
-    skip_public: false
+    per_file_processors: []
   )
     Logging.section('👋 Hi!') do
       intro = Packs.config.user_event_logger.before_move_to_pack(pack_name)
@@ -98,8 +93,7 @@ module Packs
     Private.move_to_pack!(
       pack_name: pack_name,
       paths_relative_to_root: paths_relative_to_root,
-      per_file_processors: per_file_processors,
-      skip_public: skip_public
+      per_file_processors: per_file_processors
     )
 
     Logging.section('Next steps') do

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -56,20 +56,23 @@ module Packs
       pack_name: String,
       enforce_privacy: T::Boolean,
       enforce_dependencies: T.nilable(T::Boolean),
-      team: T.nilable(CodeTeams::Team)
+      team: T.nilable(CodeTeams::Team),
+      skip_public: T.nilable(T::Boolean)
     ).void
   end
   def self.create_pack!(
     pack_name:,
     enforce_privacy: true,
     enforce_dependencies: nil,
-    team: nil
+    team: nil,
+    skip_public: false
   )
     Private.create_pack!(
       pack_name: pack_name,
       enforce_privacy: enforce_privacy,
       enforce_dependencies: enforce_dependencies,
-      team: team
+      team: team,
+      skip_public: skip_public
     )
   end
 
@@ -77,13 +80,15 @@ module Packs
     params(
       pack_name: String,
       paths_relative_to_root: T::Array[String],
-      per_file_processors: T::Array[PerFileProcessorInterface]
+      per_file_processors: T::Array[PerFileProcessorInterface],
+      skip_public: T.nilable(T::Boolean)
     ).void
   end
   def self.move_to_pack!(
     pack_name:,
     paths_relative_to_root: [],
-    per_file_processors: []
+    per_file_processors: [],
+    skip_public: false
   )
     Logging.section('👋 Hi!') do
       intro = Packs.config.user_event_logger.before_move_to_pack(pack_name)
@@ -93,7 +98,8 @@ module Packs
     Private.move_to_pack!(
       pack_name: pack_name,
       paths_relative_to_root: paths_relative_to_root,
-      per_file_processors: per_file_processors
+      per_file_processors: per_file_processors,
+      skip_public: skip_public
     )
 
     Logging.section('Next steps') do

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -8,13 +8,11 @@ module Packs
 
     desc 'create packs/your_pack', 'Create pack with name packs/your_pack'
     option :enforce_privacy, type: :boolean, default: true, aliases: :p, banner: 'Enforce privacy'
-    option :skip_public, type: :boolean, default: false, aliases: :P, banner: 'Skip creating public directory'
     sig { params(pack_name: String).void }
     def create(pack_name)
       Packs.create_pack!(
         pack_name: pack_name,
-        enforce_privacy: options[:enforce_privacy],
-        skip_public: options[:skip_public]
+        enforce_privacy: options[:enforce_privacy]
       )
       exit_successfully
     end
@@ -90,14 +88,12 @@ module Packs
 
       Make sure there are no spaces between the comma-separated list of paths of directories.
     LONG_DESC
-    option :skip_public, type: :boolean, default: false, aliases: :P, banner: "Skip creating public directory with TODO.md file if it doesn't exist already"
     sig { params(pack_name: String, paths: String).void }
     def move(pack_name, *paths)
       Packs.move_to_pack!(
         pack_name: pack_name,
         paths_relative_to_root: paths,
-        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new],
-        skip_public: options[:skip_public]
+        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
       )
       exit_successfully
     end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -7,9 +7,15 @@ module Packs
     extend T::Sig
 
     desc 'create packs/your_pack', 'Create pack with name packs/your_pack'
+    option :enforce_privacy, type: :boolean, default: true, aliases: :p, banner: 'Enforce privacy'
+    option :skip_public, type: :boolean, default: false, aliases: :P, banner: 'Skip creating public directory'
     sig { params(pack_name: String).void }
     def create(pack_name)
-      Packs.create_pack!(pack_name: pack_name)
+      Packs.create_pack!(
+        pack_name: pack_name,
+        enforce_privacy: options[:enforce_privacy],
+        skip_public: options[:skip_public]
+      )
       exit_successfully
     end
 
@@ -84,12 +90,14 @@ module Packs
 
       Make sure there are no spaces between the comma-separated list of paths of directories.
     LONG_DESC
+    option :skip_public, type: :boolean, default: false, aliases: :P, banner: "Skip creating public directory with TODO.md file if it doesn't exist already"
     sig { params(pack_name: String, paths: String).void }
     def move(pack_name, *paths)
       Packs.move_to_pack!(
         pack_name: pack_name,
         paths_relative_to_root: paths,
-        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
+        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new],
+        skip_public: options[:skip_public]
       )
       exit_successfully
     end

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -46,11 +46,10 @@ module Packs
         pack_name: String,
         enforce_privacy: T::Boolean,
         enforce_dependencies: T.nilable(T::Boolean),
-        team: T.nilable(CodeTeams::Team),
-        skip_public: T.nilable(T::Boolean)
+        team: T.nilable(CodeTeams::Team)
       ).void
     end
-    def self.create_pack!(pack_name:, enforce_privacy:, enforce_dependencies:, team:, skip_public: false)
+    def self.create_pack!(pack_name:, enforce_privacy:, enforce_dependencies:, team:)
       Logging.section('👋 Hi!') do
         intro = Packs.config.user_event_logger.before_create_pack(pack_name)
         Logging.print_bold_green(intro)
@@ -59,7 +58,7 @@ module Packs
       pack_name = Private.clean_pack_name(pack_name)
 
       package = create_pack_if_not_exists!(pack_name: pack_name, enforce_privacy: enforce_privacy, enforce_dependencies: enforce_dependencies, team: team)
-      add_public_directory(package) if package.enforce_privacy && !skip_public
+      add_public_directory(package) if package.enforce_privacy
       add_readme_todo(package)
 
       Logging.section('Next steps') do
@@ -73,18 +72,17 @@ module Packs
       params(
         pack_name: String,
         paths_relative_to_root: T::Array[String],
-        per_file_processors: T::Array[Packs::PerFileProcessorInterface],
-        skip_public: T.nilable(T::Boolean)
+        per_file_processors: T::Array[Packs::PerFileProcessorInterface]
       ).void
     end
-    def self.move_to_pack!(pack_name:, paths_relative_to_root:, per_file_processors: [], skip_public: false)
+    def self.move_to_pack!(pack_name:, paths_relative_to_root:, per_file_processors: [])
       pack_name = Private.clean_pack_name(pack_name)
       package = ParsePackwerk.all.find { |p| p.name == pack_name }
       if package.nil?
         raise StandardError, "Can not find package with name #{pack_name}. Make sure the argument is of the form `packs/my_pack/`"
       end
 
-      add_public_directory(package) if package.enforce_privacy && !skip_public
+      add_public_directory(package) if package.enforce_privacy
       add_readme_todo(package)
       package_location = package.directory
 

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -46,10 +46,11 @@ module Packs
         pack_name: String,
         enforce_privacy: T::Boolean,
         enforce_dependencies: T.nilable(T::Boolean),
-        team: T.nilable(CodeTeams::Team)
+        team: T.nilable(CodeTeams::Team),
+        skip_public: T.nilable(T::Boolean)
       ).void
     end
-    def self.create_pack!(pack_name:, enforce_privacy:, enforce_dependencies:, team:)
+    def self.create_pack!(pack_name:, enforce_privacy:, enforce_dependencies:, team:, skip_public: false)
       Logging.section('👋 Hi!') do
         intro = Packs.config.user_event_logger.before_create_pack(pack_name)
         Logging.print_bold_green(intro)
@@ -58,7 +59,7 @@ module Packs
       pack_name = Private.clean_pack_name(pack_name)
 
       package = create_pack_if_not_exists!(pack_name: pack_name, enforce_privacy: enforce_privacy, enforce_dependencies: enforce_dependencies, team: team)
-      add_public_directory(package)
+      add_public_directory(package) if package.enforce_privacy && !skip_public
       add_readme_todo(package)
 
       Logging.section('Next steps') do
@@ -72,17 +73,18 @@ module Packs
       params(
         pack_name: String,
         paths_relative_to_root: T::Array[String],
-        per_file_processors: T::Array[Packs::PerFileProcessorInterface]
+        per_file_processors: T::Array[Packs::PerFileProcessorInterface],
+        skip_public: T.nilable(T::Boolean)
       ).void
     end
-    def self.move_to_pack!(pack_name:, paths_relative_to_root:, per_file_processors: [])
+    def self.move_to_pack!(pack_name:, paths_relative_to_root:, per_file_processors: [], skip_public: false)
       pack_name = Private.clean_pack_name(pack_name)
       package = ParsePackwerk.all.find { |p| p.name == pack_name }
       if package.nil?
         raise StandardError, "Can not find package with name #{pack_name}. Make sure the argument is of the form `packs/my_pack/`"
       end
 
-      add_public_directory(package)
+      add_public_directory(package) if package.enforce_privacy && !skip_public
       add_readme_todo(package)
       package_location = package.directory
 

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.28'
+  spec.version       = '0.0.29'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/spec/packs/private/cli_spec.rb
+++ b/spec/packs/private/cli_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Packs::CLI do
   describe '#create' do
     it 'creates a pack' do
       expect_success
-      expect(Packs).to receive(:create_pack!).with(pack_name: 'packs/your_pack')
+      expect(Packs).to receive(:create_pack!).with(pack_name: 'packs/your_pack', enforce_privacy: true, skip_public: false)
       Packs::CLI.start(['create', 'packs/your_pack'])
     end
   end

--- a/spec/packs/private/cli_spec.rb
+++ b/spec/packs/private/cli_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Packs::CLI do
   describe '#create' do
     it 'creates a pack' do
       expect_success
-      expect(Packs).to receive(:create_pack!).with(pack_name: 'packs/your_pack', enforce_privacy: true, skip_public: false)
+      expect(Packs).to receive(:create_pack!).with(pack_name: 'packs/your_pack', enforce_privacy: true)
       Packs::CLI.start(['create', 'packs/your_pack'])
     end
   end

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -222,6 +222,30 @@ RSpec.describe Packs do
           actual_todo = Pathname.new('packs/organisms/app/public/TODO.md').read
           expect(actual_todo).to eq expected_todo
         end
+
+        context 'skipping creation of public directory' do
+          it 'does not add a TODO.md file' do
+            Packs.create_pack!(pack_name: 'packs/organisms', skip_public: true)
+
+            ParsePackwerk.bust_cache!
+            package = ParsePackwerk.find('packs/organisms')
+            expect(package.enforce_privacy).to eq(true)
+            todo_file = Pathname.new('packs/organisms/app/public/TODO.md')
+            expect(todo_file.exist?).to eq false
+          end
+        end
+
+        context 'pack not enforcing privacy' do
+          it 'does not add a TODO.md file' do
+            Packs.create_pack!(pack_name: 'packs/organisms', enforce_privacy: false)
+
+            ParsePackwerk.bust_cache!
+            package = ParsePackwerk.find('packs/organisms')
+            expect(package.enforce_privacy).to eq(false)
+            todo_file = Pathname.new('packs/organisms/app/public/TODO.md')
+            expect(todo_file.exist?).to eq false
+          end
+        end
       end
 
       context 'app with one file in public dir' do
@@ -286,6 +310,13 @@ RSpec.describe Packs do
   end
 
   describe '.move_to_pack!' do
+    before do
+      write_file('packwerk.yml', <<~YML)
+        require:
+          - packwerk/privacy/checker
+      YML
+    end
+
     context 'pack is not nested' do
       context 'pack not yet created' do
         it 'errors' do
@@ -695,6 +726,35 @@ RSpec.describe Packs do
 
           actual_todo = Pathname.new('packs/organisms/app/public/TODO.md').read
           expect(actual_todo).to eq expected_todo
+        end
+
+        context 'skipping creation of public directory' do
+          it 'does not add a TODO.md file' do
+            write_file('app/services/foo.rb')
+            write_package_yml('packs/organisms')
+            Packs.move_to_pack!(
+              pack_name: 'packs/organisms',
+              paths_relative_to_root: ['app/services/foo.rb'],
+              skip_public: true
+            )
+
+            todo_file = Pathname.new('packs/organisms/app/public/TODO.md')
+            expect(todo_file.exist?).to eq false
+          end
+        end
+
+        context 'pack not enforcing privacy' do
+          it 'does not add a TODO.md file' do
+            write_file('app/services/foo.rb')
+            write_package_yml('packs/organisms', enforce_privacy: false)
+            Packs.move_to_pack!(
+              pack_name: 'packs/organisms',
+              paths_relative_to_root: ['app/services/foo.rb']
+            )
+
+            todo_file = Pathname.new('packs/organisms/app/public/TODO.md')
+            expect(todo_file.exist?).to eq false
+          end
         end
       end
 

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -223,18 +223,6 @@ RSpec.describe Packs do
           expect(actual_todo).to eq expected_todo
         end
 
-        context 'skipping creation of public directory' do
-          it 'does not add a TODO.md file' do
-            Packs.create_pack!(pack_name: 'packs/organisms', skip_public: true)
-
-            ParsePackwerk.bust_cache!
-            package = ParsePackwerk.find('packs/organisms')
-            expect(package.enforce_privacy).to eq(true)
-            todo_file = Pathname.new('packs/organisms/app/public/TODO.md')
-            expect(todo_file.exist?).to eq false
-          end
-        end
-
         context 'pack not enforcing privacy' do
           it 'does not add a TODO.md file' do
             Packs.create_pack!(pack_name: 'packs/organisms', enforce_privacy: false)
@@ -726,21 +714,6 @@ RSpec.describe Packs do
 
           actual_todo = Pathname.new('packs/organisms/app/public/TODO.md').read
           expect(actual_todo).to eq expected_todo
-        end
-
-        context 'skipping creation of public directory' do
-          it 'does not add a TODO.md file' do
-            write_file('app/services/foo.rb')
-            write_package_yml('packs/organisms')
-            Packs.move_to_pack!(
-              pack_name: 'packs/organisms',
-              paths_relative_to_root: ['app/services/foo.rb'],
-              skip_public: true
-            )
-
-            todo_file = Pathname.new('packs/organisms/app/public/TODO.md')
-            expect(todo_file.exist?).to eq false
-          end
         end
 
         context 'pack not enforcing privacy' do


### PR DESCRIPTION
I decided to send this PR because in our project we're not ready to enforce privacy in many packs just yet and I've had to repeatedly keep deleting the autogenerated `public/TODO.md` file each time I create a new pack or move files to an already existing pack without enforcing privacy.

This PR:
* Allows passing `--no-enforce-privacy` to `create` to optionally create a pack without enforcing privacy in which case the public dir won't be forcefully created.
* When moving files to a pack which doesn't enforce privacy, it won't forcefully create the public dir either.

I was also adding a `-P` option to both `create` and `move` commands to allow skipping automatic creation of `public/TODO.md` when moving files to a pack not having a public directory, or when creating a pack without enforcing privacy. But this required adding a new parameter to the public API and Sorbet didn't like it, so I removed that new option.

