### PR TITLE
Support CSV format for `get_info` and allow including any violation types

### DIFF
--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -129,6 +129,7 @@ module Packs
     end
 
     desc 'get_info [ packs/my_pack packs/my_other_pack ]', 'Get info about size and violations for packs'
+    option :include_date, type: :boolean, default: false, aliases: :d, banner: "Include today's date as part of the data (useful to take snapshots over time)"
     option :format, type: :string, default: 'detail', aliases: :f, banner: 'Specify the output format (detail, csv)'
     option :types, type: :string, default: 'privacy,dependency', aliases: :t, banner: 'List of validation types to include (privacy,dependency,architecture)'
     sig { params(pack_names: String).void }
@@ -140,7 +141,8 @@ module Packs
       Private.get_info(
         packs: parse_pack_names(pack_names),
         format: options[:format].to_sym,
-        types: selected_types.map(&:to_sym)
+        types: selected_types.map(&:to_sym),
+        include_date: options[:include_date]
       )
       exit_successfully
     end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -130,11 +130,17 @@ module Packs
 
     desc 'get_info [ packs/my_pack packs/my_other_pack ]', 'Get info about size and violations for packs'
     option :format, type: :string, default: 'detail', aliases: :f, banner: 'Specify the output format (detail, csv)'
+    option :types, type: :string, default: 'privacy,dependency', aliases: :t, banner: 'List of validation types to include (privacy,dependency,architecture)'
     sig { params(pack_names: String).void }
     def get_info(*pack_names)
+      selected_types = options[:types].to_s.downcase.split(',')
+      invalid_types = selected_types - POSIBLE_TYPES
+      raise StandardError, "Invalid type(s): #{invalid_types.join(', ')}. Possible types are: #{POSIBLE_TYPES.join(', ')}" unless invalid_types.empty?
+
       Private.get_info(
         packs: parse_pack_names(pack_names),
-        format: options[:format].to_sym
+        format: options[:format].to_sym,
+        types: selected_types.map(&:to_sym)
       )
       exit_successfully
     end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -129,9 +129,13 @@ module Packs
     end
 
     desc 'get_info [ packs/my_pack packs/my_other_pack ]', 'Get info about size and violations for packs'
+    option :format, type: :string, default: 'detail', aliases: :f, banner: 'Specify the output format (detail, csv)'
     sig { params(pack_names: String).void }
     def get_info(*pack_names)
-      Private.get_info(packs: parse_pack_names(pack_names))
+      Private.get_info(
+        packs: parse_pack_names(pack_names),
+        format: options[:format].to_sym
+      )
       exit_successfully
     end
 

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -482,19 +482,19 @@ module Packs
     sig do
       params(
         packs: T::Array[Packs::Pack],
-        format: Symbol
+        format: Symbol,
+        types: T::Array[Symbol]
       ).void
     end
-    def self.get_info(packs: Packs.all, format: :detail)
+    def self.get_info(packs: Packs.all, format: :detail, types: %i[privacy dependency architecture])
       require 'csv' if format == :csv
 
-      violation_types = %i[privacy dependency architecture]
       violations = {
         inbound: {},
         outbound: {}
       }
       directions = violations.keys
-      dir_x_types = directions.product(violation_types)
+      dir_x_types = directions.product(types)
 
       ParsePackwerk.all.each do |p|
         p.violations.each do |violation|

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -499,10 +499,10 @@ module Packs
         all_outbound += outbound_violations[pack.name] || []
       end
 
-      puts "There are #{all_inbound.select(&:privacy?).sum { |v| v.files.count }} total inbound privacy violations"
-      puts "There are #{all_inbound.select(&:dependency?).sum { |v| v.files.count }} total inbound dependency violations"
-      puts "There are #{all_outbound.select(&:privacy?).sum { |v| v.files.count }} total outbound privacy violations"
-      puts "There are #{all_outbound.select(&:dependency?).sum { |v| v.files.count }} total outbound dependency violations"
+      puts "There are #{all_inbound.select { _1.type == 'privacy' }.sum { |v| v.files.count }} total inbound privacy violations"
+      puts "There are #{all_inbound.select { _1.type == 'dependency' }.sum { |v| v.files.count }} total inbound dependency violations"
+      puts "There are #{all_outbound.select { _1.type == 'privacy' }.sum { |v| v.files.count }} total outbound privacy violations"
+      puts "There are #{all_outbound.select { _1.type == 'dependency' }.sum { |v| v.files.count }} total outbound dependency violations"
 
       packs.sort_by { |p| -p.relative_path.glob('**/*.rb').count }.each do |pack|
         owner = CodeOwnership.for_package(pack)
@@ -516,12 +516,12 @@ module Packs
           public_api: pack.relative_path.join('app/public'),
           violations: {
             dependency: {
-              in: inbound_for_pack.flatten.select(&:dependency?).sum { |v| v.files.count },
-              out: outbound_for_pack.flatten.select(&:dependency?).sum { |v| v.files.count }
+              in: inbound_for_pack.flatten.select { _1.type == 'dependency' }.sum { |v| v.files.count },
+              out: outbound_for_pack.flatten.select { _1.type == 'dependency' }.sum { |v| v.files.count }
             },
             privacy: {
-              in: inbound_for_pack.select(&:privacy?).sum { |v| v.files.count },
-              out: outbound_for_pack.select(&:privacy?).sum { |v| v.files.count }
+              in: inbound_for_pack.select { _1.type == 'privacy' }.sum { |v| v.files.count },
+              out: outbound_for_pack.select { _1.type == 'privacy' }.sum { |v| v.files.count }
             }
           }
         }

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -488,7 +488,7 @@ module Packs
     def self.get_info(packs: Packs.all, format: :detail)
       require 'csv' if format == :csv
 
-      violation_types = %i[privacy dependency]
+      violation_types = %i[privacy dependency architecture]
       violations = {
         inbound: {},
         outbound: {}

--- a/lib/packs/private/interactive_cli/use_cases/get_info.rb
+++ b/lib/packs/private/interactive_cli/use_cases/get_info.rb
@@ -26,9 +26,11 @@ module Packs
               selected_packs = PackSelector.single_or_all_pack_multi_select(prompt, question_text: 'What pack(s) would you like info on?')
             end
 
+            format = prompt.select('What output format do you want?', %w[Detail CSV])
+
             puts "You've selected #{selected_packs.count} packs. Wow! Here's all the info."
 
-            Private.get_info(packs: selected_packs)
+            Private.get_info(packs: selected_packs, format: format.downcase.to_sym)
           end
         end
       end

--- a/lib/packs/private/interactive_cli/use_cases/get_info.rb
+++ b/lib/packs/private/interactive_cli/use_cases/get_info.rb
@@ -33,12 +33,15 @@ module Packs
               %w[Privacy Dependency Architecture]
             )
 
+            include_date = !prompt.no?('Should the current date be included in the report?')
+
             puts "You've selected #{selected_packs.count} packs. Wow! Here's all the info."
 
             Private.get_info(
               packs: selected_packs,
               format: format.downcase.to_sym,
-              types: types.map(&:downcase).map(&:to_sym)
+              types: types.map(&:downcase).map(&:to_sym),
+              include_date: include_date
             )
           end
         end

--- a/lib/packs/private/interactive_cli/use_cases/get_info.rb
+++ b/lib/packs/private/interactive_cli/use_cases/get_info.rb
@@ -28,9 +28,18 @@ module Packs
 
             format = prompt.select('What output format do you want?', %w[Detail CSV])
 
+            types = prompt.multi_select(
+              'What violation types do you want stats for?',
+              %w[Privacy Dependency Architecture]
+            )
+
             puts "You've selected #{selected_packs.count} packs. Wow! Here's all the info."
 
-            Private.get_info(packs: selected_packs, format: format.downcase.to_sym)
+            Private.get_info(
+              packs: selected_packs,
+              format: format.downcase.to_sym,
+              types: types.map(&:downcase).map(&:to_sym)
+            )
           end
         end
       end


### PR DESCRIPTION
This PR refactors code from `get_info` to easily allow other violation types besides `privacy` and `dependency`. On top of that, it allows outputting per-pack data in CSV format.

That being said, the default output remains being exactly the same as before.

I think the CSV format is very valuable because it can easily be used for getting periodic progress reports and even transform it to other formats via external tools (JSON, markdown table, etc). I'm personally using it to generate a markdown table from it.

Example using default "detail" format and picking dependency and architecture violations:

```
$ bin/packs get_info -t dependency,architecture packs/foo packs/bar packs/baz
There are 58 total inbound dependency violations
There are 20 total inbound architecture violations
There are 171 total outbound dependency violations
There are 149 total outbound architecture violations

=========== Info about: packs/bar
Owned by: No one
Size: 47 ruby files
Public API: packs/bar/app/public
There are 17 inbound dependency violations
There are 0 inbound architecture violations
There are 117 outbound dependency violations
There are 117 outbound architecture violations

=========== Info about: packs/baz
Owned by: No one
Size: 18 ruby files
Public API: packs/baz/app/public
There are 31 inbound dependency violations
There are 10 inbound architecture violations
There are 50 outbound dependency violations
There are 32 outbound architecture violations

=========== Info about: packs/foo
Owned by: No one
Size: 9 ruby files
Public API: packs/foo/app/public
There are 10 inbound dependency violations
There are 10 inbound architecture violations
There are 4 outbound dependency violations
There are 0 outbound architecture violations
```

Same data, but using CSV format:
```
$ bin/packs get_info -f csv -t dependency,architecture packs/foo packs/bar packs/baz
Pack name,Owned by,Size,Public API,Inbound dependency violations,Inbound architecture violations,Outbound dependency violations,Outbound architecture violations
packs/bar,No one,47,packs/bar/app/public,17,0,117,117
packs/baz,No one,18,packs/baz/app/public,31,10,50,32
packs/foo,No one,9,packs/foo/app/public,10,10,4,0
```
