### PR TITLE
Make sure to require tmpdir before using mktmpdir

### DIFF
--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 require 'fileutils'
+require 'tmpdir'
 require 'rainbow'
 require 'sorbet-runtime'
 


### PR DESCRIPTION
I was running into this problem when upgrading to the latest packs (0.0.24 to 0.0.29):

```
❯ DISABLE_SPRING=1 bin/packs lint_package_todo_yml_files
📦 Packwerk is inspecting 30396 files
............

✅ `package_todo.yml` has been updated.
/Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/packs-0.0.29/lib/packs/private.rb:438:in `diff_package_todo_yml': undefined method `mktmpdir' for Dir:Class (NoMethodError)

      dir_containing_contents_before = Dir.mktmpdir
                                          ^^^^^^^^^
Did you mean?  mkdir
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/packs-0.0.29/lib/packs/private.rb:528:in `lint_package_todo_yml_files!'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/packs-0.0.29/lib/packs.rb:229:in `lint_package_todo_yml_files!'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/packs-0.0.29/lib/packs/cli.rb:104:in `lint_package_todo_yml_files'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10983/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
        from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/packs-0.0.29/bin/packs:9:in `<top (required)>'
        from bin/packs:27:in `load'
        from bin/packs:27:in `<main>'
```

Weirdly, adding a `binding.irb` at the line before that call let's it work. Turns out, `tmpdir` is what provides this method and it has to be required first. irb must require that for that to have work.