### PR TITLE
Modify ignore dependencies when move_pack_to_parent

### DIFF
--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -199,13 +199,20 @@ module Packs
           new_dependencies += [new_package_name]
         end
 
+        new_config = other_package.config.dup
+        if new_config['ignored_dependencies']
+          new_config['ignored_dependencies'] = new_config['ignored_dependencies'].map do |d|
+            d == pack_name ? new_package_name : d
+          end
+        end
+
         new_other_package = ParsePackwerk::Package.new(
           name: other_package.name,
           enforce_privacy: other_package.enforce_privacy,
           enforce_dependencies: other_package.enforce_dependencies,
           dependencies: new_dependencies.uniq.sort,
           metadata: other_package.metadata,
-          config: other_package.config
+          config: new_config
         )
 
         ParsePackwerk.write_package_yml!(new_other_package)

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -1124,6 +1124,21 @@ RSpec.describe Packs do
       expect(ParsePackwerk.find('packs/fruits').dependencies).to eq(['packs/fruits/apples'])
     end
 
+    it 'updates ignored_dependencies in all package.yml' do
+      write_package_yml('packs/fruits')
+      write_package_yml('packs/apples', dependencies: ['packs/other_pack'], metadata: { 'custom_field' => 'custom value' })
+      write_package_yml('packs/turtles', config: { 'ignored_dependencies' => ['packs/apples'] })
+
+      Packs.move_to_parent!(
+        pack_name: 'packs/apples',
+        parent_name: 'packs/fruits'
+      )
+
+      ParsePackwerk.bust_cache!
+
+      expect(ParsePackwerk.find('packs/turtles').config['ignored_dependencies']).to eq(['packs/fruits/apples'])
+    end
+
     it 'gives some helpful output to users' do
       logged_output = ''
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,8 @@ sig do
     enforce_privacy: T::Boolean,
     visible_to: T::Array[String],
     metadata: T.untyped,
-    owner: T.nilable(String)
+    owner: T.nilable(String),
+    config: T::Hash[String, T.untyped]
   ).void
 end
 def write_package_yml(
@@ -48,7 +49,8 @@ def write_package_yml(
   enforce_privacy: true,
   visible_to: [],
   metadata: {},
-  owner: nil
+  owner: nil,
+  config: {}
 )
   if owner
     metadata.merge!({ 'owner' => owner })
@@ -60,7 +62,7 @@ def write_package_yml(
     enforce_dependencies: enforce_dependencies,
     enforce_privacy: enforce_privacy,
     metadata: metadata,
-    config: {}
+    config: config
   )
 
   ParsePackwerk.write_package_yml!(package)


### PR DESCRIPTION
When moving a pack under a parent pack, update `ignored_depedencies` for other packs.