### PR TITLE
lift per_file_processors defaults to Packs from Packs::CLI

### DIFF
--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -82,7 +82,7 @@ module Packs
   def self.move_to_pack!(
     pack_name:,
     paths_relative_to_root: [],
-    per_file_processors: []
+    per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
   )
     Logging.section('👋 Hi!') do
       intro = Packs.config.user_event_logger.before_move_to_pack(pack_name)
@@ -163,7 +163,7 @@ module Packs
   def self.move_to_parent!(
     pack_name:,
     parent_name:,
-    per_file_processors: []
+    per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
   )
     Logging.section('👋 Hi!') do
       intro = Packs.config.user_event_logger.before_move_to_parent(pack_name)

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -109,7 +109,7 @@ module Packs
   end
   def self.make_public!(
     paths_relative_to_root: [],
-    per_file_processors: []
+    per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
   )
     Logging.section('Making files public') do
       intro = Packs.config.user_event_logger.before_make_public

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -74,10 +74,7 @@ module Packs
     LONG_DESC
     sig { params(paths: String).void }
     def make_public(*paths)
-      Packs.make_public!(
-        paths_relative_to_root: paths,
-        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
-      )
+      Packs.make_public!(paths_relative_to_root: paths)
       exit_successfully
     end
 

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -92,8 +92,7 @@ module Packs
     def move(pack_name, *paths)
       Packs.move_to_pack!(
         pack_name: pack_name,
-        paths_relative_to_root: paths,
-        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
+        paths_relative_to_root: paths
       )
       exit_successfully
     end
@@ -159,8 +158,7 @@ module Packs
     def move_to_parent(child_pack_name, parent_pack_name)
       Packs.move_to_parent!(
         parent_name: parent_pack_name,
-        pack_name: child_pack_name,
-        per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
+        pack_name: child_pack_name
       )
       exit_successfully
     end


### PR DESCRIPTION
Because these options feel like "advanced" things to be aware of when calling these methods, and because they feel like reasonable defaults, we lifted them up from `Packs::CLI` to `Packs`.