### PR TITLE
fix enforce privacy flag when creating new pack in Packs::move_to_parent!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.32)
+    packs (0.0.33)
       code_ownership (>= 1.33.0)
       packs-specification
       packwerk

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -170,7 +170,7 @@ module Packs
 
       new_package = ParsePackwerk::Package.new(
         name: new_package_name,
-        enforce_privacy: package.enforce_dependencies,
+        enforce_privacy: package.enforce_privacy,
         enforce_dependencies: package.enforce_dependencies,
         dependencies: package.dependencies,
         metadata: package.metadata,

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.32'
+  spec.version       = '0.0.33'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
In `move_to_parent`, the process of moving a pack is:

1. Create a new `package.yml` in the target location with the attributes of the pack being moved
2. Move the files to the new location using `move_to_pack!`
3. Delete the original `package.yml` for the moved pack

In step 1, we were setting `enforce_privacy` for the new `package.yml` to the value of the original pack's `enforce_dependencies` flag instead of its `enforce_privacy` flag.

I tried to write a spec for this behavior, but when writing package yml the `enforce_privacy` flag was always getting written as `false`... I think because the [privacy extension](https://github.com/rubyatscale/parse_packwerk/blob/main/lib/parse_packwerk.rb#L71-L73) is disabled in the test suite.