### PR TITLE
Do not add dependency to parent pack if subpack is ignored dependency

### DIFF
--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -195,15 +195,18 @@ module Packs
 
       ParsePackwerk.all.each do |other_package|
         new_dependencies = other_package.dependencies.map { |d| d == pack_name ? new_package_name : d }
-        if other_package.name == parent_name && !new_dependencies.include?(new_package_name)
-          new_dependencies += [new_package_name]
-        end
 
         new_config = other_package.config.dup
         if new_config['ignored_dependencies']
           new_config['ignored_dependencies'] = new_config['ignored_dependencies'].map do |d|
             d == pack_name ? new_package_name : d
           end
+        end
+
+        if other_package.name == parent_name &&
+          !new_dependencies.include?(new_package_name) &&
+          !new_config['ignored_dependencies']&.include?(new_package_name)
+          new_dependencies += [new_package_name]
         end
 
         new_other_package = ParsePackwerk::Package.new(

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -204,8 +204,8 @@ module Packs
         end
 
         if other_package.name == parent_name &&
-          !new_dependencies.include?(new_package_name) &&
-          !new_config['ignored_dependencies']&.include?(new_package_name)
+           !new_dependencies.include?(new_package_name) &&
+           !new_config['ignored_dependencies']&.include?(new_package_name)
           new_dependencies += [new_package_name]
         end
 

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -1139,6 +1139,23 @@ RSpec.describe Packs do
       expect(ParsePackwerk.find('packs/turtles').config['ignored_dependencies']).to eq(['packs/fruits/apples'])
     end
 
+    context 'when the pack is an ignored dependency of the parent pack' do
+      it 'does not add a dependency' do
+        write_package_yml('packs/fruits', config: { 'ignored_dependencies' => ['packs/apples'] })
+        write_package_yml('packs/apples', dependencies: ['packs/other_pack'], metadata: { 'custom_field' => 'custom value' })
+
+        Packs.move_to_parent!(
+          pack_name: 'packs/apples',
+          parent_name: 'packs/fruits'
+        )
+
+        ParsePackwerk.bust_cache!
+
+        expect(ParsePackwerk.find('packs/fruits').config['ignored_dependencies']).to eq(['packs/fruits/apples'])
+        expect(ParsePackwerk.find('packs/fruits').dependencies).to be_empty
+      end
+    end
+
     it 'gives some helpful output to users' do
       logged_output = ''
 


### PR DESCRIPTION
If we have a file like this for `packs/fruit`:
`fruit.yml`
```
dependencies:
  - packs/orange
ignored_dependencies:
  - packs/apple
```
and we move `packs/apple` under the parent `packs/fruit`, we get
```
dependencies:
  - packs/orange
  - packs/fruit/apple
ignored_dependencies:
  - packs/fruit/apple
```

This PR changes `move_to_parent` such that this is now the output:
```
dependencies:
  - packs/orange
ignored_dependencies:
  - packs/fruit/apple
```