### PR TITLE
Allow packs to be created anywhere

### DIFF
--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -24,12 +24,6 @@ require 'packs/cli'
 module Packs
   extend T::Sig
 
-  PERMITTED_PACK_LOCATIONS = T.let(%w[
-                                     gems
-                                     components
-                                     packs
-                                   ], T::Array[String])
-
   sig { void }
   def self.start_interactive_mode!
     Private::InteractiveCli.start!

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -370,8 +370,9 @@ module Packs
       ).returns(ParsePackwerk::Package)
     end
     def self.create_pack_if_not_exists!(pack_name:, enforce_privacy:, enforce_dependencies:, team: nil)
-      if PERMITTED_PACK_LOCATIONS.none? { |permitted_location| pack_name.start_with?(permitted_location) }
-        raise StandardError, "Packs only supports packages in the the following directories: #{PERMITTED_PACK_LOCATIONS.inspect}. Please make sure to pass in the name of the pack including the full directory path, e.g. `packs/my_pack`."
+      allowed_locations = Packs::Specification.config.pack_paths
+      if allowed_locations.none? { |location| File.fnmatch(location, pack_name) }
+        raise StandardError, "Packs only supports packages in the the following directories: #{allowed_locations}. Please make sure to pass in the name of the pack including the full directory path, e.g. `packs/my_pack`."
       end
 
       existing_package = ParsePackwerk.all.find { |p| p.name == pack_name }

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Packs do
 
       it 'errors' do
         expect { Packs.create_pack!(pack_name: 'foo/my_pack') }.to raise_error(
-          'Packs only supports packages in the the following directories: ["gems", "components", "packs"]. Please make sure to pass in the name of the pack including the full directory path, e.g. `packs/my_pack`.'
+          'Packs only supports packages in the the following directories: ["packs/*", "packs/*/*"]. Please make sure to pass in the name of the pack including the full directory path, e.g. `packs/my_pack`.'
         )
       end
     end
@@ -160,6 +160,10 @@ RSpec.describe Packs do
 
     context 'pack is in gems' do
       let(:pack_name) { 'gems/my_pack' }
+
+      before do
+        allow(Packs::Specification.config).to receive(:pack_paths).and_return(['gems/*'])
+      end
 
       it 'creates the pack' do
         Packs.create_pack!(pack_name: 'gems/my_pack')


### PR DESCRIPTION
`packs` is able to find packs anywhere, as long as those locations are
specified in `packs.yml`.
