### PR TITLE
add the move_to_folder command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.36)
+    packs (0.0.37)
       code_ownership (>= 1.33.0)
       packs-specification
       packwerk

--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ Make sure there are no spaces between the comma-separated list of paths of direc
 `bin/packs rename`
 
 ## Set packs/child_pack as a child of packs/parent_pack
-`bin/packs move_to_parent packs/child_pack packs/parent_pack `
+`bin/packs move_to_parent packs/child_pack packs/parent_pack`
+
+## Move packs/foo to the packs/bar folder
+`bin/packs move_to_folder packs/foo packs/bar`
 
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Make sure there are no spaces between the comma-separated list of paths of direc
 ## Set packs/child_pack as a child of packs/parent_pack
 `bin/packs move_to_parent packs/child_pack packs/parent_pack`
 
-## Move packs/foo to the packs/bar folder
-`bin/packs move_to_folder packs/foo packs/bar`
+## Move packs/foo to the some/directory folder, where some/directory does not contain a package.yml file
+`bin/packs move_to_folder packs/foo some/directory`
 
 
 ## Releasing

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -180,6 +180,36 @@ module Packs
 
   sig do
     params(
+      pack_name: String,
+      destination: String,
+      per_file_processors: T::Array[PerFileProcessorInterface]
+    ).void
+  end
+  def self.move_to_folder!(
+    pack_name:,
+    destination:,
+    per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
+  )
+    Logging.section('👋 Hi!') do
+      intro = Packs.config.user_event_logger.before_move_to_parent(pack_name) # TODO
+      Logging.print_bold_green(intro)
+    end
+
+    Private.move_to_folder!(
+      pack_name: pack_name,
+      destination: destination,
+      per_file_processors: per_file_processors
+    )
+
+    Logging.section('Next steps') do
+      next_steps = Packs.config.user_event_logger.after_move_to_parent(pack_name) # TODO
+
+      Logging.print_bold_green(next_steps)
+    end
+  end
+
+  sig do
+    params(
       type: String,
       pack_name: T.nilable(String),
       limit: Integer

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -191,7 +191,7 @@ module Packs
     per_file_processors: [Packs::RubocopPostProcessor.new, Packs::CodeOwnershipPostProcessor.new]
   )
     Logging.section('👋 Hi!') do
-      intro = Packs.config.user_event_logger.before_move_to_parent(pack_name) # TODO
+      intro = Packs.config.user_event_logger.before_move_to_folder(pack_name)
       Logging.print_bold_green(intro)
     end
 
@@ -202,7 +202,7 @@ module Packs
     )
 
     Logging.section('Next steps') do
-      next_steps = Packs.config.user_event_logger.after_move_to_parent(pack_name) # TODO
+      next_steps = Packs.config.user_event_logger.after_move_to_folder(pack_name)
 
       Logging.print_bold_green(next_steps)
     end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -150,12 +150,22 @@ module Packs
       exit_successfully
     end
 
-    desc 'move_to_parent packs/child_pack packs/parent_pack ', 'Set packs/child_pack as a child of packs/parent_pack'
+    desc 'move_to_parent packs/child_pack packs/parent_pack', 'Set packs/child_pack as a child of packs/parent_pack'
     sig { params(child_pack_name: String, parent_pack_name: String).void }
     def move_to_parent(child_pack_name, parent_pack_name)
       Packs.move_to_parent!(
         parent_name: parent_pack_name,
         pack_name: child_pack_name
+      )
+      exit_successfully
+    end
+
+    desc 'move_to_folder packs/foo packs/bar', 'Move packs/foo to the packs/bar folder'
+    sig { params(pack_name: String, destination: String).void }
+    def move_to_folder(pack_name, destination)
+      Packs.move_to_folder!(
+        pack_name: pack_name,
+        destination: destination
       )
       exit_successfully
     end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -160,7 +160,7 @@ module Packs
       exit_successfully
     end
 
-    desc 'move_to_folder packs/foo packs/bar', 'Move packs/foo to the packs/bar folder'
+    desc 'move_to_folder packs/foo some/directory', 'Move packs/foo to the some/directory folder, where some/directory does not contain a package.yml file'
     sig { params(pack_name: String, destination: String).void }
     def move_to_folder(pack_name, destination)
       Packs.move_to_folder!(

--- a/lib/packs/user_event_logger.rb
+++ b/lib/packs/user_event_logger.rb
@@ -106,6 +106,24 @@ module Packs
     end
 
     sig { params(pack_name: String).returns(String) }
+    def before_move_to_folder(pack_name)
+      <<~MSG
+        You are moving one pack to a new directory. Check out #{documentation_link} for more info!
+      MSG
+    end
+
+    sig { params(pack_name: String).returns(String) }
+    def after_move_to_folder(pack_name)
+      <<~MSG
+        Your next steps might be:
+
+        1) Delete the old pack when things look good: `git rm -r #{pack_name}`
+
+        2) Run `bin/packwerk update-todo` to update the violations. Make sure to run `spring stop` first.
+      MSG
+    end
+
+    sig { params(pack_name: String).returns(String) }
     def on_create_public_directory_todo(pack_name)
       <<~MSG
         This directory holds your public API!

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.36'
+  spec.version       = '0.0.37'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
`move_to_folder` works like `move_to_parent`, except it doesn't treat the destination like pack. It still updates `package.yml`, `package_todo.yml`, and Sorbet files that reference the moved pack, but it does not create a `package.yml` file in the target directory. It also does not modify the `package.yml` if it already exists (e.g., it will not add the moved pack as a dependency).

In addition to the specs, I tested this against the Gusto codebase and the command worked as expected.

