### PR TITLE
add enforce_architecture flag wherever enforce_privacy is used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Shopify/packwerk.git
-  revision: e850241a4572a984bc9def8307faef7271c6890b
+  revision: c27be1b1bc917d088fa46484414f303d81217117
   branch: main
   specs:
     packwerk (3.1.0)
@@ -21,7 +21,7 @@ PATH
       code_ownership (>= 1.33.0)
       packs-specification
       packwerk
-      parse_packwerk
+      parse_packwerk (>= 0.22.0)
       rainbow
       sorbet-runtime
       thor
@@ -81,7 +81,7 @@ GEM
     packs-specification (0.0.10)
       sorbet-runtime
     parallel (1.23.0)
-    parse_packwerk (0.20.1)
+    parse_packwerk (0.22.0)
       sorbet-runtime
     parser (3.2.2.3)
       ast (~> 2.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.37)
+    packs (0.0.38)
       code_ownership (>= 1.33.0)
       packs-specification
       packwerk

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -49,6 +49,7 @@ module Packs
     params(
       pack_name: String,
       enforce_privacy: T::Boolean,
+      enforce_architecture: T::Boolean,
       enforce_dependencies: T.nilable(T::Boolean),
       team: T.nilable(CodeTeams::Team)
     ).void
@@ -56,6 +57,7 @@ module Packs
   def self.create_pack!(
     pack_name:,
     enforce_privacy: true,
+    enforce_architecture: true,
     enforce_dependencies: nil,
     team: nil
   )
@@ -63,6 +65,7 @@ module Packs
       pack_name: pack_name,
       enforce_privacy: enforce_privacy,
       enforce_dependencies: enforce_dependencies,
+      enforce_architecture: enforce_architecture,
       team: team
     )
   end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -7,12 +7,16 @@ module Packs
     extend T::Sig
 
     desc 'create packs/your_pack', 'Create pack with name packs/your_pack'
+    option :enforce_dependencies, type: :boolean, default: nil, aliases: :d, banner: 'Enforce dependencies'
     option :enforce_privacy, type: :boolean, default: true, aliases: :p, banner: 'Enforce privacy'
+    option :enforce_architecture, type: :boolean, default: true, aliases: :a, banner: 'Enforce architecture'
     sig { params(pack_name: String).void }
     def create(pack_name)
       Packs.create_pack!(
         pack_name: pack_name,
-        enforce_privacy: options[:enforce_privacy]
+        enforce_dependencies: options[:enforce_dependencies],
+        enforce_privacy: options[:enforce_privacy],
+        enforce_architecture: options[:enforce_architecture]
       )
       exit_successfully
     end

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.37'
+  spec.version       = '0.0.38'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'code_ownership', '>= 1.33.0'
   spec.add_dependency 'packs-specification'
   spec.add_dependency 'packwerk'
-  spec.add_dependency 'parse_packwerk'
+  spec.add_dependency 'parse_packwerk', '>= 0.22.0'
   spec.add_dependency 'rainbow'
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'thor'

--- a/sorbet/rbi/gems/.gitattributes
+++ b/sorbet/rbi/gems/.gitattributes
@@ -1,0 +1,1 @@
+**/*.rbi linguist-generated=true

--- a/sorbet/rbi/gems/packs-specification@0.0.10.rbi
+++ b/sorbet/rbi/gems/packs-specification@0.0.10.rbi
@@ -11,7 +11,7 @@
 # source://packs-specification//lib/packs/pack.rb#3
 module Packs
   class << self
-    # source://packs/0.1.0/lib/packs.rb#122
+    # source://packs/0.0.37/lib/packs.rb#134
     sig { params(pack_name: ::String, dependency_name: ::String).void }
     def add_dependency!(pack_name:, dependency_name:); end
 
@@ -19,32 +19,33 @@ module Packs
     sig { returns(T::Array[::Packs::Pack]) }
     def all; end
 
-    # source://packs/0.1.0/lib/packs.rb#220
+    # source://packs/0.0.37/lib/packs.rb#249
     sig { void }
     def bust_cache!; end
 
-    # source://packs/0.1.0/lib/packs/configuration.rb#50
+    # source://packs/0.0.37/lib/packs.rb#44
+    sig { params(files: T::Array[::String]).returns(T::Boolean) }
+    def check(files); end
+
+    # source://packs/0.0.37/lib/packs/configuration.rb#50
     sig { returns(::Packs::Configuration) }
     def config; end
 
-    # source://packs/0.1.0/lib/packs/configuration.rb#57
+    # source://packs/0.0.37/lib/packs/configuration.rb#57
     sig { params(blk: T.proc.params(arg0: ::Packs::Configuration).void).void }
     def configure(&blk); end
 
-    # source://packs/0.1.0/lib/packs.rb#47
+    # source://packs/0.0.37/lib/packs.rb#57
     sig do
       params(
         pack_name: ::String,
         enforce_privacy: T::Boolean,
+        enforce_architecture: T::Boolean,
         enforce_dependencies: T.nilable(T::Boolean),
         team: T.nilable(::CodeTeams::Team)
       ).void
     end
-    def create_pack!(pack_name:, enforce_privacy: T.unsafe(nil), enforce_dependencies: T.unsafe(nil), team: T.unsafe(nil)); end
-
-    # source://packs/0.1.0/lib/packs.rb#229
-    sig { params(argv: T.untyped, formatter: T.nilable(::Packwerk::OffensesFormatter)).void }
-    def execute(argv, formatter = T.unsafe(nil)); end
+    def create_pack!(pack_name:, enforce_privacy: T.unsafe(nil), enforce_architecture: T.unsafe(nil), enforce_dependencies: T.unsafe(nil), team: T.unsafe(nil)); end
 
     # source://packs-specification//lib/packs-specification.rb#24
     sig { params(name: ::String).returns(T.nilable(::Packs::Pack)) }
@@ -54,31 +55,19 @@ module Packs
     sig { params(file_path: T.any(::Pathname, ::String)).returns(T.nilable(::Packs::Pack)) }
     def for_file(file_path); end
 
-    # source://packs/0.1.0/lib/packs.rb#236
-    sig { params(files: T::Array[::String]).returns(T::Array[::Packwerk::ReferenceOffense]) }
-    def get_offenses_for_files(files); end
-
-    # source://packs/0.1.0/lib/packs.rb#243
-    sig { params(files: T::Array[::String]).returns(T::Array[::Packwerk::ReferenceOffense]) }
-    def get_offenses_for_files_by_package(files); end
-
-    # source://packs/0.1.0/lib/packs.rb#252
+    # source://packs/0.0.37/lib/packs.rb#255
     sig { void }
     def lint_package_todo_yml_files!; end
 
-    # source://packs/0.1.0/lib/packs.rb#257
+    # source://packs/0.0.37/lib/packs.rb#260
     sig { params(packs: T::Array[::Packs::Pack]).void }
     def lint_package_yml_files!(packs); end
 
-    # source://packs/0.1.0/lib/packs.rb#194
-    sig { params(pack_name: T.nilable(::String), limit: ::Integer).void }
-    def list_top_dependency_violations(pack_name:, limit:); end
+    # source://packs/0.0.37/lib/packs.rb#221
+    sig { params(type: ::String, pack_name: T.nilable(::String), limit: ::Integer).void }
+    def list_top_violations(type:, pack_name:, limit:); end
 
-    # source://packs/0.1.0/lib/packs.rb#178
-    sig { params(pack_name: T.nilable(::String), limit: ::Integer).void }
-    def list_top_privacy_violations(pack_name:, limit:); end
-
-    # source://packs/0.1.0/lib/packs.rb#96
+    # source://packs/0.0.37/lib/packs.rb#108
     sig do
       params(
         paths_relative_to_root: T::Array[::String],
@@ -87,7 +76,17 @@ module Packs
     end
     def make_public!(paths_relative_to_root: T.unsafe(nil), per_file_processors: T.unsafe(nil)); end
 
-    # source://packs/0.1.0/lib/packs.rb#68
+    # source://packs/0.0.37/lib/packs.rb#191
+    sig do
+      params(
+        pack_name: ::String,
+        destination: ::String,
+        per_file_processors: T::Array[::Packs::PerFileProcessorInterface]
+      ).void
+    end
+    def move_to_folder!(pack_name:, destination:, per_file_processors: T.unsafe(nil)); end
+
+    # source://packs/0.0.37/lib/packs.rb#80
     sig do
       params(
         pack_name: ::String,
@@ -97,7 +96,7 @@ module Packs
     end
     def move_to_pack!(pack_name:, paths_relative_to_root: T.unsafe(nil), per_file_processors: T.unsafe(nil)); end
 
-    # source://packs/0.1.0/lib/packs.rb#149
+    # source://packs/0.0.37/lib/packs.rb#161
     sig do
       params(
         pack_name: ::String,
@@ -107,13 +106,21 @@ module Packs
     end
     def move_to_parent!(pack_name:, parent_name:, per_file_processors: T.unsafe(nil)); end
 
-    # source://packs/0.1.0/lib/packs.rb#211
+    # source://packs/0.0.37/lib/packs.rb#240
     sig { params(file: ::String, find: ::Pathname, replace_with: ::Pathname).void }
     def replace_in_file(file:, find:, replace_with:); end
 
-    # source://packs/0.1.0/lib/packs.rb#35
+    # source://packs/0.0.37/lib/packs.rb#29
     sig { void }
     def start_interactive_mode!; end
+
+    # source://packs/0.0.37/lib/packs.rb#34
+    sig { returns(T::Boolean) }
+    def update; end
+
+    # source://packs/0.0.37/lib/packs.rb#39
+    sig { returns(T::Boolean) }
+    def validate; end
   end
 end
 
@@ -148,7 +155,7 @@ class Packs::Pack < ::T::Struct
     sig { params(package_yml_absolute_path: ::Pathname).returns(::Packs::Pack) }
     def from(package_yml_absolute_path); end
 
-    # source://sorbet-runtime/0.5.10826/lib/types/struct.rb#13
+    # source://sorbet-runtime/0.5.11151/lib/types/struct.rb#13
     def inherited(s); end
   end
 end
@@ -201,7 +208,7 @@ class Packs::Specification::Configuration < ::T::Struct
     sig { returns(::Packs::Specification::Configuration) }
     def fetch; end
 
-    # source://sorbet-runtime/0.5.10826/lib/types/struct.rb#13
+    # source://sorbet-runtime/0.5.11151/lib/types/struct.rb#13
     def inherited(s); end
 
     # source://packs-specification//lib/packs/specification/configuration.rb#26

--- a/sorbet/rbi/gems/parse_packwerk@0.21.0.rbi
+++ b/sorbet/rbi/gems/parse_packwerk@0.21.0.rbi
@@ -8,26 +8,41 @@
 module ParsePackwerk
   class << self
     # source://parse_packwerk//lib/parse_packwerk.rb#37
-    sig { returns(T::Array[::ParsePackwerk::Package]) }; def all; end
-    # source://parse_packwerk//lib/parse_packwerk.rb#132
-    sig { void }; def bust_cache!; end
+    sig { returns(T::Array[::ParsePackwerk::Package]) }
+    def all; end
+
+    # source://parse_packwerk//lib/parse_packwerk.rb#136
+    sig { void }
+    def bust_cache!; end
+
     # source://parse_packwerk//lib/parse_packwerk.rb#42
-    sig { params(name: ::String).returns(T.nilable(::ParsePackwerk::Package)) }; def find(name); end
-    # source://parse_packwerk//lib/parse_packwerk.rb#101
-    sig { returns(T::Array[::String]) }; def key_sort_order; end
+    sig { params(name: ::String).returns(T.nilable(::ParsePackwerk::Package)) }
+    def find(name); end
+
+    # source://parse_packwerk//lib/parse_packwerk.rb#105
+    sig { returns(T::Array[::String]) }
+    def key_sort_order; end
+
     # source://parse_packwerk//lib/parse_packwerk.rb#52
-    sig { params(file_path: T.any(::Pathname, ::String)).returns(::ParsePackwerk::Package) }; def package_from_path(file_path); end
+    sig { params(file_path: T.any(::Pathname, ::String)).returns(::ParsePackwerk::Package) }
+    def package_from_path(file_path); end
+
     # source://parse_packwerk//lib/parse_packwerk.rb#63
-    sig { params(package: ::ParsePackwerk::Package).void }; def write_package_yml!(package); end
+    sig { params(package: ::ParsePackwerk::Package).void }
+    def write_package_yml!(package); end
+
     # source://parse_packwerk//lib/parse_packwerk.rb#47
-    sig { returns(::ParsePackwerk::Configuration) }; def yml; end
+    sig { returns(::ParsePackwerk::Configuration) }
+    def yml; end
+
     private
 
     # We memoize packages_by_name for fast lookup.
     # Since Graph is an immutable value object, we can create indexes and general caching mechanisms safely.
     #
-    # source://parse_packwerk//lib/parse_packwerk.rb#120
-    sig { returns(T::Hash[::String, ::ParsePackwerk::Package]) }; def packages_by_name; end
+    # source://parse_packwerk//lib/parse_packwerk.rb#124
+    sig { returns(T::Hash[::String, ::ParsePackwerk::Package]) }
+    def packages_by_name; end
   end
 end
 
@@ -40,31 +55,39 @@ class ParsePackwerk::Configuration < ::T::Struct
 
   class << self
     # source://parse_packwerk//lib/parse_packwerk/configuration.rb#32
-    sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(T::Array[::String]) }; def excludes(config_hash); end
+    sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(T::Array[::String]) }
+    def excludes(config_hash); end
+
     # source://parse_packwerk//lib/parse_packwerk/configuration.rb#13
-    sig { returns(::ParsePackwerk::Configuration) }; def fetch; end
-    # source://sorbet-runtime/0.5.10993/lib/types/struct.rb#13
+    sig { returns(::ParsePackwerk::Configuration) }
+    def fetch; end
+
+    # source://sorbet-runtime/0.5.11151/lib/types/struct.rb#13
     def inherited(s); end
 
     # source://parse_packwerk//lib/parse_packwerk/configuration.rb#44
-    sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(T::Array[::String]) }; def package_paths(config_hash); end
+    sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(T::Array[::String]) }
+    def package_paths(config_hash); end
   end
 end
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#22
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#23
 ParsePackwerk::DEFAULT_EXCLUDE_GLOBS = T.let(T.unsafe(nil), Array)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#23
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#24
 ParsePackwerk::DEFAULT_PACKAGE_PATHS = T.let(T.unsafe(nil), Array)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#24
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#25
 ParsePackwerk::DEFAULT_PUBLIC_PATH = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#14
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#15
 ParsePackwerk::DEPENDENCIES = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#10
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#11
 ParsePackwerk::DEPENDENCY_VIOLATION_TYPE = T.let(T.unsafe(nil), String)
+
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#10
+ParsePackwerk::ENFORCE_ARCHITECTURE = T.let(T.unsafe(nil), String)
 
 # source://parse_packwerk//lib/parse_packwerk/constants.rb#8
 ParsePackwerk::ENFORCE_DEPENDENCIES = T.let(T.unsafe(nil), String)
@@ -76,25 +99,33 @@ ParsePackwerk::ENFORCE_PRIVACY = T.let(T.unsafe(nil), String)
 module ParsePackwerk::Extensions
   class << self
     # source://parse_packwerk//lib/parse_packwerk/extensions.rb#8
-    sig { returns(T::Boolean) }; def all_extensions_installed?; end
+    sig { returns(T::Boolean) }
+    def all_extensions_installed?; end
+
+    # source://parse_packwerk//lib/parse_packwerk/extensions.rb#18
+    sig { returns(T::Boolean) }
+    def architecture_extension_installed?; end
+
     # source://parse_packwerk//lib/parse_packwerk/extensions.rb#13
-    sig { returns(T::Boolean) }; def privacy_extension_installed?; end
+    sig { returns(T::Boolean) }
+    def privacy_extension_installed?; end
   end
 end
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#13
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#14
 ParsePackwerk::METADATA = T.let(T.unsafe(nil), String)
 
 # Since this metadata is unstructured YAML, it could be any type. We leave it to clients of `ParsePackwerk::Package`
 # to add types based on their known usage of metadata.
 #
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#18
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#19
 ParsePackwerk::MetadataYmlType = T.type_alias { T::Hash[T.untyped, T.untyped] }
 
 # source://parse_packwerk//lib/parse_packwerk.rb#23
 class ParsePackwerk::MissingConfiguration < ::StandardError
   # source://parse_packwerk//lib/parse_packwerk.rb#27
-  sig { params(packwerk_file_name: ::Pathname).void }; def initialize(packwerk_file_name); end
+  sig { params(packwerk_file_name: ::Pathname).void }
+  def initialize(packwerk_file_name); end
 end
 
 # source://parse_packwerk//lib/parse_packwerk/constants.rb#7
@@ -106,39 +137,58 @@ ParsePackwerk::PACKAGE_YML_NAME = T.let(T.unsafe(nil), String)
 # source://parse_packwerk//lib/parse_packwerk/constants.rb#6
 ParsePackwerk::PACKWERK_YML_NAME = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#11
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#12
 ParsePackwerk::PRIVACY_VIOLATION_TYPE = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#12
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#13
 ParsePackwerk::PUBLIC_PATH = T.let(T.unsafe(nil), String)
 
 # source://parse_packwerk//lib/parse_packwerk/package.rb#4
 class ParsePackwerk::Package < ::T::Struct
   const :name, ::String
-  const :enforce_dependencies, T.any(::String, T::Boolean)
+  const :enforce_dependencies, T.nilable(T.any(::String, T::Boolean))
   const :enforce_privacy, T.any(::String, T::Boolean), default: T.unsafe(nil)
+  const :enforce_architecture, T.any(::String, T::Boolean), default: T.unsafe(nil)
   const :public_path, ::String, default: T.unsafe(nil)
   const :metadata, T::Hash[T.untyped, T.untyped]
   const :dependencies, T::Array[::String]
   const :config, T::Hash[T.untyped, T.untyped]
   const :violations, T::Array[::ParsePackwerk::Violation]
 
-  # source://parse_packwerk//lib/parse_packwerk/package.rb#48
-  sig { returns(::Pathname) }; def directory; end
-  # source://parse_packwerk//lib/parse_packwerk/package.rb#58
-  sig { returns(T.any(::String, T::Boolean)) }; def enforces_dependencies?; end
-  # source://parse_packwerk//lib/parse_packwerk/package.rb#63
-  sig { returns(T.any(::String, T::Boolean)) }; def enforces_privacy?; end
-  # source://parse_packwerk//lib/parse_packwerk/package.rb#53
-  sig { returns(::Pathname) }; def public_directory; end
-  # source://parse_packwerk//lib/parse_packwerk/package.rb#43
-  sig { returns(::Pathname) }; def yml; end
+  # source://parse_packwerk//lib/parse_packwerk/package.rb#50
+  sig { returns(::Pathname) }
+  def directory; end
+
+  # source://parse_packwerk//lib/parse_packwerk/package.rb#70
+  sig { returns(T.any(::String, T::Boolean)) }
+  def enforces_architecture?; end
+
+  # source://parse_packwerk//lib/parse_packwerk/package.rb#60
+  sig { returns(T.nilable(T.any(::String, T::Boolean))) }
+  def enforces_dependencies?; end
+
+  # source://parse_packwerk//lib/parse_packwerk/package.rb#65
+  sig { returns(T.any(::String, T::Boolean)) }
+  def enforces_privacy?; end
+
+  # source://parse_packwerk//lib/parse_packwerk/package.rb#55
+  sig { returns(::Pathname) }
+  def public_directory; end
+
+  # source://parse_packwerk//lib/parse_packwerk/package.rb#45
+  sig { returns(::Pathname) }
+  def yml; end
+
   class << self
-    # source://parse_packwerk//lib/parse_packwerk/package.rb#38
-    sig { params(package_name: ::String).returns(::Pathname) }; def directory(package_name); end
-    # source://parse_packwerk//lib/parse_packwerk/package.rb#17
-    sig { params(pathname: ::Pathname).returns(::ParsePackwerk::Package) }; def from(pathname); end
-    # source://sorbet-runtime/0.5.10993/lib/types/struct.rb#13
+    # source://parse_packwerk//lib/parse_packwerk/package.rb#40
+    sig { params(package_name: ::String).returns(::Pathname) }
+    def directory(package_name); end
+
+    # source://parse_packwerk//lib/parse_packwerk/package.rb#18
+    sig { params(pathname: ::Pathname).returns(::ParsePackwerk::Package) }
+    def from(pathname); end
+
+    # source://sorbet-runtime/0.5.11151/lib/types/struct.rb#13
     def inherited(s); end
   end
 end
@@ -161,7 +211,8 @@ class ParsePackwerk::PackageSet
     private
 
     # source://parse_packwerk//lib/parse_packwerk/package_set.rb#28
-    sig { params(globs: T::Array[::String], path: ::Pathname).returns(T::Boolean) }; def exclude_path?(globs, path); end
+    sig { params(globs: T::Array[::String], path: ::Pathname).returns(T::Boolean) }
+    def exclude_path?(globs, path); end
   end
 end
 
@@ -172,14 +223,19 @@ class ParsePackwerk::PackageTodo < ::T::Struct
 
   class << self
     # source://parse_packwerk//lib/parse_packwerk/package_todo.rb#11
-    sig { params(package: ::ParsePackwerk::Package).returns(::ParsePackwerk::PackageTodo) }; def for(package); end
+    sig { params(package: ::ParsePackwerk::Package).returns(::ParsePackwerk::PackageTodo) }
+    def for(package); end
+
     # source://parse_packwerk//lib/parse_packwerk/package_todo.rb#16
-    sig { params(pathname: ::Pathname).returns(::ParsePackwerk::PackageTodo) }; def from(pathname); end
-    # source://sorbet-runtime/0.5.10993/lib/types/struct.rb#13
+    sig { params(pathname: ::Pathname).returns(::ParsePackwerk::PackageTodo) }
+    def from(pathname); end
+
+    # source://sorbet-runtime/0.5.11151/lib/types/struct.rb#13
     def inherited(s); end
 
     # source://parse_packwerk//lib/parse_packwerk/package_todo.rb#46
-    sig { params(dirname: ::Pathname).returns(::Pathname) }; def yml(dirname); end
+    sig { params(dirname: ::Pathname).returns(::Pathname) }
+    def yml(dirname); end
   end
 end
 
@@ -194,11 +250,15 @@ class ParsePackwerk::Violation < ::T::Struct
   const :files, T::Array[::String]
 
   # source://parse_packwerk//lib/parse_packwerk/violation.rb#13
-  sig { returns(T::Boolean) }; def dependency?; end
+  sig { returns(T::Boolean) }
+  def dependency?; end
+
   # source://parse_packwerk//lib/parse_packwerk/violation.rb#18
-  sig { returns(T::Boolean) }; def privacy?; end
+  sig { returns(T::Boolean) }
+  def privacy?; end
+
   class << self
-    # source://sorbet-runtime/0.5.10993/lib/types/struct.rb#13
+    # source://sorbet-runtime/0.5.11151/lib/types/struct.rb#13
     def inherited(s); end
   end
 end

--- a/spec/packs/private/cli_spec.rb
+++ b/spec/packs/private/cli_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Packs::CLI do
   describe '#create' do
     it 'creates a pack' do
       expect_success
-      expect(Packs).to receive(:create_pack!).with(pack_name: 'packs/your_pack', enforce_privacy: true)
+      expect(Packs).to receive(:create_pack!).with(pack_name: 'packs/your_pack', enforce_dependencies: nil, enforce_privacy: true, enforce_architecture: true)
       Packs::CLI.start(['create', 'packs/your_pack'])
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,8 +35,9 @@ sig do
     pack_name: String,
     dependencies: T::Array[String],
     violations: T::Array[ParsePackwerk::Violation],
-    enforce_dependencies: T::Boolean,
+    enforce_dependencies: T.nilable(T::Boolean),
     enforce_privacy: T::Boolean,
+    enforce_architecture: T::Boolean,
     visible_to: T::Array[String],
     metadata: T.untyped,
     owner: T.nilable(String),
@@ -49,6 +50,7 @@ def write_package_yml(
   violations: [],
   enforce_dependencies: true,
   enforce_privacy: true,
+  enforce_architecture: true,
   visible_to: [],
   metadata: {},
   owner: nil,
@@ -64,6 +66,7 @@ def write_package_yml(
     violations: violations,
     enforce_dependencies: enforce_dependencies,
     enforce_privacy: enforce_privacy,
+    enforce_architecture: enforce_architecture,
     metadata: metadata,
     config: config
   )


### PR DESCRIPTION
The `packs` half of https://github.com/rubyatscale/parse_packwerk/pull/39.

This PR adds an `enforce_architecture` flag wherever `enforce_privacy` is used, bringing parity between the two extensions for `packs` functionality (namely, setting these flags in `package.yml` files when packs are created or moved).