### PR TITLE
update publish rubygems action to ruby 3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
       - name: Tag and Push Gem
         id: tag-and-push-gem
-        uses: discourse/publish-rubygems-action@04549cca4eecd343acd215114ebbbdb99630af90
+        uses: discourse/publish-rubygems-action@4bd305c65315cb691bad1e8de97a87aaf29a0a85
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GIT_EMAIL: ${{secrets.ALEX_GIT_EMAIL}}


### PR DESCRIPTION
We're attempting to fix [this](https://github.com/rubyatscale/packs/actions/runs/7224931276) failing CD action on main by updating the publish-rubygems-action step to the latest version, which uses Ruby 3 instead of 2.7.