### PR TITLE
handle (most) packages that are not packs

### DIFF
--- a/lib/packs/update_references_post_processor.rb
+++ b/lib/packs/update_references_post_processor.rb
@@ -15,7 +15,7 @@ module Packs
     def after_move_files!(file_move_operations)
       return if file_move_operations.empty?
 
-      origin_pack = T.must(file_move_operations.first).origin_pack.name
+      origin_pack = T.must(file_move_operations.first).origin_pack&.name || ParsePackwerk::ROOT_PACKAGE_NAME
       destination_pack = T.must(file_move_operations.first).destination_pack.name
 
       if self.class.ripgrep_enabled?

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -375,6 +375,23 @@ RSpec.describe Packs do
                               ])
       end
 
+      it 'can move files from non-pack packages into a pack' do
+        target_pack = 'packs/animals'
+        file_to_move = 'lib/tasks/donkey.rake'
+        write_file(file_to_move)
+        write_package_yml('lib')
+
+        write_package_yml(target_pack)
+        Packs.move_to_pack!(
+          pack_name: target_pack,
+          paths_relative_to_root: [file_to_move]
+        )
+
+        expect_files_to_not_exist([file_to_move])
+
+        expect_files_to_exist([File.join(target_pack, file_to_move)])
+      end
+
       it 'can move directories from a monolith and their specs into a package' do
         write_file('app/services/horse_like/donkey.rb')
         write_file('spec/services/horse_like/donkey_spec.rb')


### PR DESCRIPTION
`packs` seems a little confused about what is a pack. Packs are packwerk packages that have additional functionality sprinkled on top. Not all packwerk packages are packs, and thus not all packwerk packages have engine-like structure.

This leads to `packs move` having really surprising behavior when moving files out of a non-pack package, as demonstrated by the regression spec included in this PR. Note that every app has at least one package that is not a pack: The root package. This was already handled as a special case.

`origin_pack = ParsePackwerk.package_from_path(origin_pathname)` exemplifies this incorrect assumption: It fetches a _package_ and then assigns it to a variable called _pack_ and proceeds to make assumptions that don't hold for packages that are not packs. Luckily, `packs-specification` has methods for finding packs, specifically. We should use those.

I have manually tested this on One Medical's main monolith.

Fixes https://github.com/rubyatscale/packs/issues/146

## Caveat
Technically, the behavior implemented for packs would also apply for non-packs with engine-like structure. I think that's a bit too much of a special case; if someone is using `packs` and has engine-like packages it seems reasonable to assume that they are packs.

## Additional Notes

- Why would you want to make `lib` a package?
  - See https://simplexity.quest/posts/2023-12-23-lib-is-for-libraries
- This work is sponsored by https://www.onemedical.com/