### PR TITLE
use universal darwin platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,10 +190,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
-  x86_64-darwin-22
-  x86_64-darwin-23
+  universal-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
* [x] I bumped the gem version (or don't need to) 💎

- Adds the universal-darwin platform to hopefully stop the persistent sorbet-static bundler issues we run into
