### PR TITLE
lock parse packwerk version to <= 0.23.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.41)
+    packs (0.0.42)
       bigdecimal
       code_ownership (>= 1.33.0)
       packs-specification

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       code_ownership (>= 1.33.0)
       packs-specification
       packwerk
-      parse_packwerk (>= 0.22.0)
+      parse_packwerk (>= 0.22.0, <= 0.23.0)
       rainbow
       sorbet-runtime
       thor

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.41'
+  spec.version       = '0.0.42'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'code_ownership', '>= 1.33.0'
   spec.add_dependency 'packs-specification'
   spec.add_dependency 'packwerk'
-  spec.add_dependency 'parse_packwerk', '>= 0.22.0'
+  spec.add_dependency 'parse_packwerk', '>= 0.22.0', '<= 0.23.0'
   spec.add_dependency 'rainbow'
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'thor'


### PR DESCRIPTION
* [x] I bumped the gem version (or don't need to) 💎

https://github.com/rubyatscale/parse_packwerk has been updated to use "layers" instead of "architecture" but `packs` has not yet. When we do update this gem, we can remove the version cap.