### PR TITLE
Fix lib file moves

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.44)
+    packs (0.0.45)
       bigdecimal
       code_ownership (>= 1.33.0)
       packs-specification

--- a/lib/packs/private/file_move_operation.rb
+++ b/lib/packs/private/file_move_operation.rb
@@ -55,7 +55,7 @@ module Packs
       def spec_file_move_operation
         path_parts = filepath_without_pack_name.split('/')
         folder = T.must(path_parts[0])
-        file_extension = filepath_without_pack_name.split('.').last
+        file_extension = T.must(filepath_without_pack_name.split('.').last)
 
         # This could probably be implemented by some "strategy pattern" where different extension types are handled by different helpers
         # Such a thing could also include, for example, when moving a controller, moving its ERB view too.

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.44'
+  spec.version       = '0.0.45'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -567,6 +567,32 @@ RSpec.describe Packs do
         end
       end
 
+      context 'files moved are ruby files in lib' do
+        it 'can move files from lib from one pack to another pack' do
+          write_package_yml('packs/my_pack')
+          write_package_yml('packs/organisms')
+          write_file('packs/organisms/lib/my_ruby_file.rb')
+          write_file('packs/organisms/spec/lib/my_ruby_file_spec.rb')
+
+          Packs.move_to_pack!(
+            pack_name: 'packs/my_pack',
+            paths_relative_to_root: [
+              'packs/organisms/lib/my_ruby_file.rb'
+            ]
+          )
+
+          expect_files_to_not_exist([
+                                      'packs/organisms/lib/my_ruby_file.rb',
+                                      'packs/organisms/spec/lib/my_ruby_file_spec.rb'
+                                    ])
+
+          expect_files_to_exist([
+                                  'packs/my_pack/lib/my_ruby_file.rb',
+                                  'packs/my_pack/spec/lib/my_ruby_file_spec.rb'
+                                ])
+        end
+      end
+
       describe 'RubocopPostProcessor' do
         context 'moving file listed in top-level .rubocop_todo.yml' do
           it 'modifies an application-specific file, .rubocop_todo.yml, correctly' do


### PR DESCRIPTION
* [x] I bumped the gem version (or don't need to) 💎

This PR fixes the following issue, resulting in the expected behavior.

## Expected behavior

When moving a file to a new pack, the file moves, the corresponding spec moves, and the rubocop TODO file is updated.

Running `bin/packs move packs/product_services/payroll/payroll_agency_onboarding packs/admin/developer_utils/lib/alt_sftp_helper.rb` results in the following diff:

```
modified:   .rubocop_todo.yml
renamed:    packs/admin/developer_utils/lib/alt_sftp_helper.rb -> packs/product_services/payroll/payroll_agency_onboarding/lib/alt_sftp_helper.rb
renamed:    packs/admin/developer_utils/spec/lib/alt_sftp_helper_spec.rb -> packs/product_services/payroll/payroll_agency_onboarding/spec/lib/alt_sftp_helper_spec.rb
```

## Actual behavior

When moving a file to a new pack, the file moves and the rubocop TODO file is updated.

Running `bin/packs move packs/product_services/payroll/payroll_agency_onboarding packs/admin/developer_utils/lib/alt_sftp_helper.rb` results in the following diff:

```
modified:   .rubocop_todo.yml
renamed:    packs/admin/developer_utils/lib/alt_sftp_helper.rb -> packs/product_services/payroll/payroll_agency_onboarding/lib/alt_sftp_helper.rb
```
