### PR TITLE
Make README template customizable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packs (0.0.45)
+    packs (0.1.0)
       bigdecimal
       code_ownership (>= 1.33.0)
       packs-specification

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ pack_paths:
   - gems/* # gems can be packs too!
 ```
 
+To customize the README template, include a `README_TEMPLATE.md` file in the root of your project. If you want to use a custom path for your README template, you can specify it in the `packs.yml` file in the root of your project:
+```yml
+readme_template_path: my_folder/README_STUFF.md
+```
+
 # Ecosystem
 The rest of the [rubyatscale](https://github.com/rubyatscale) ecosystem is intended to help make using packs and improving the boundaries between them more clear.
 

--- a/lib/packs/configuration.rb
+++ b/lib/packs/configuration.rb
@@ -7,6 +7,9 @@ module Packs
   class Configuration
     extend T::Sig
 
+    CONFIGURATION_PATHNAME = T.let(Pathname.new('packs.yml'), Pathname)
+    DEFAULT_README_TEMPLATE_PATHNAME = T.let(Pathname.new('README_TEMPLATE.md'), Pathname)
+
     sig { params(enforce_dependencies: T::Boolean).void }
     attr_writer :enforce_dependencies
 
@@ -44,6 +47,18 @@ module Packs
     sig { returns(T::Boolean) }
     def default_enforce_dependencies
       true
+    end
+
+    sig { returns(Pathname) }
+    def readme_template_pathname
+      config_hash = CONFIGURATION_PATHNAME.exist? ? YAML.load_file(CONFIGURATION_PATHNAME) : {}
+
+      specified_readme_template_path = config_hash['readme_template_path']
+      if specified_readme_template_path.nil?
+        DEFAULT_README_TEMPLATE_PATHNAME
+      else
+        Pathname.new(specified_readme_template_path)
+      end
     end
   end
 

--- a/lib/packs/user_event_logger.rb
+++ b/lib/packs/user_event_logger.rb
@@ -148,6 +148,11 @@ module Packs
 
     sig { params(pack_name: String).returns(String) }
     def on_create_readme_todo(pack_name)
+      readme_template_pathname = Packs.config.readme_template_pathname
+      readme_template = readme_template_pathname.read if readme_template_pathname.exist?
+
+      return readme_template unless readme_template.nil?
+
       <<~MSG
         Welcome to `#{pack_name}`!
 

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.45'
+  spec.version       = '0.1.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -351,11 +351,11 @@ RSpec.describe Packs do
           end
 
           it 'uses the template to create the README_TODO.md' do
-            write_file('my_folder/README_STUFF.md', 'This is the template')
+            write_file('my_folder/README_STUFF.md', 'This is the custom template')
             Packs.create_pack!(pack_name: 'packs/organisms')
             ParsePackwerk.bust_cache!
             actual_readme_todo = ParsePackwerk.find('packs/organisms').directory.join('README_TODO.md')
-            expect(actual_readme_todo.read).to eq 'This is the template'
+            expect(actual_readme_todo.read).to eq 'This is the custom template'
           end
         end
       end

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -333,6 +333,32 @@ RSpec.describe Packs do
           expect(actual_readme_todo.exist?).to eq false
         end
       end
+
+      context 'when the app has a README template' do
+        it 'uses the template to create the README_TODO.md' do
+          write_file('README_TEMPLATE.md', 'This is the template')
+          Packs.create_pack!(pack_name: 'packs/organisms')
+          ParsePackwerk.bust_cache!
+          actual_readme_todo = ParsePackwerk.find('packs/organisms').directory.join('README_TODO.md')
+          expect(actual_readme_todo.read).to eq 'This is the template'
+        end
+
+        context 'and a custom path is specified for the README template' do
+          before do
+            write_file('packs.yml', <<~YML)
+              readme_template_path: my_folder/README_STUFF.md
+            YML
+          end
+
+          it 'uses the template to create the README_TODO.md' do
+            write_file('my_folder/README_STUFF.md', 'This is the template')
+            Packs.create_pack!(pack_name: 'packs/organisms')
+            ParsePackwerk.bust_cache!
+            actual_readme_todo = ParsePackwerk.find('packs/organisms').directory.join('README_TODO.md')
+            expect(actual_readme_todo.read).to eq 'This is the template'
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Allows users to specify a README template other than the default template currently defined in `packs`. Also allows users to specify a path to the readme template, or by default the template should be located at `README_TEMPLATE.md`. The README_TODO file currently contains the following text:

```
Welcome to `#{pack_name}`!

If you're the author, please consider replacing this file with a README.md, which may contain:
  - What your pack is and does
  - How you expect people to use your pack
  - Example usage of your pack's public API (which lives in `#{pack_name}/#{ParsePackwerk::DEFAULT_PUBLIC_PATH}`)
  - Limitations, risks, and important considerations of usage
  - How to get in touch with eng and other stakeholders for questions or issues pertaining to this pack (note: it is recommended to add ownership in `#{pack_name}/package.yml` under the `owner` metadata key)
  - What SLAs/SLOs (service level agreements/objectives), if any, your package provides
  - When in doubt, keep it simple
  - Anything else you may want to include!

 README.md files are under version control and should change as your public API changes.#{' '}

See #{documentation_link} for more info!
```

Some organizations may want to use their own README template. https://github.com/rubyatscale/packs/issues/154 requested the ability to customize the README but was closed due to inactivity.

* [x] TODO: specs
* [x] I bumped the gem version (or don't need to) 💎
