### PR TITLE
bundle with higher version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,4 +209,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.4.22
+   2.6.2


### PR DESCRIPTION
* [x] I bumped the gem version (or don't need to) 💎

Updating to use the latest version of `bundler`.
