### PR TITLE
Update move command to accept standard mv args

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ This moves a file or directory to public API (either the `app/public` folder or 
 Make sure there are no spaces between the comma-separated list of paths of directories.
 
 ## Move files or directories from one pack to another
-`bin/packs move packs/destination_pack path/to/file.rb path/to/directory`
+`bin/packs move path/to/file.rb path/to/directory packs/destination_pack`
 
 This is used for moving files into a pack (the pack must already exist).
 Note this works for moving files to packs from the monolith or from other packs
 
+The last argument is the destination pack. All previous arguments are the paths to move.
 Make sure there are no spaces between the comma-separated list of paths of directories.
 
 ## Lint `package_todo.yml` files to check for formatting issues

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -96,8 +96,8 @@ module Packs
 
       *paths, pack_name = args
       Packs.move_to_pack!(
-        pack_name: pack_name,
-        paths_relative_to_root: paths
+        pack_name: T.must(pack_name),
+        paths_relative_to_root: T.must(paths)
       )
       exit_successfully
     end

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -82,15 +82,19 @@ module Packs
       exit_successfully
     end
 
-    desc 'move packs/destination_pack path/to/file.rb path/to/directory', 'Move files or directories from one pack to another'
+    desc 'move path/to/file.rb path/to/directory packs/destination_pack', 'Move files or directories from one pack to another'
     long_desc <<~LONG_DESC
       This is used for moving files into a pack (the pack must already exist).
       Note this works for moving files to packs from the monolith or from other packs
 
+      The last argument is the destination pack. All previous arguments are the paths to move.
       Make sure there are no spaces between the comma-separated list of paths of directories.
     LONG_DESC
-    sig { params(pack_name: String, paths: String).void }
-    def move(pack_name, *paths)
+    sig { params(args: String).void }
+    def move(*args)
+      raise StandardError, 'At least two arguments required: source path(s) and destination pack' if args.length < 2
+
+      *paths, pack_name = args
       Packs.move_to_pack!(
         pack_name: pack_name,
         paths_relative_to_root: paths


### PR DESCRIPTION
* [ ] I bumped the gem version (or don't need to) 💎

Aligns the `bin/packs move` command's argument order with the standard `mv` utility.

The command now accepts arguments as `sources... destination` (last argument is the destination pack), making it more intuitive and consistent with common CLI patterns.

---
[Slack Thread](https://gustohq.slack.com/archives/C04C2NM1YRG/p1764102896011219?thread_ts=1764102896.011219&cid=C04C2NM1YRG)

<a href="https://cursor.com/background-agent?bcId=bc-79f3d512-746c-4962-bd6c-f8447c8352e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79f3d512-746c-4962-bd6c-f8447c8352e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

