### PR TITLE
Fix typos and grammatical issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure there are no spaces between the comma-separated list of paths of direc
 `bin/packs move packs/destination_pack path/to/file.rb path/to/directory`
 
 This is used for moving files into a pack (the pack must already exist).
-Note this works for moving files to packs from the monolith or from other packs
+Note this works for moving files to packs from the monolith or from other packs.
 
 Make sure there are no spaces between the comma-separated list of paths of directories.
 

--- a/advanced_usage.md
+++ b/advanced_usage.md
@@ -13,7 +13,7 @@ Packs.create_pack!(
 ### Per-file Processors
 Your application may have specific needs when moving files. `Packs` gives a way to inject application-specific behavior into the file move process.
 
-You can pass in an array of application specific behavior into the `per_file_processors` parameter of the main method.
+You can pass in an array of application-specific behavior into the `per_file_processors` parameter of the main method.
 
 See `rubocop_post_processor.rb` as an example of renaming files in `.rubocop_todo.yml` automatically, which is something you may want to do (as you do not want to fix all style errors when you're just moving a file).
 

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -85,7 +85,7 @@ module Packs
     desc 'move packs/destination_pack path/to/file.rb path/to/directory', 'Move files or directories from one pack to another'
     long_desc <<~LONG_DESC
       This is used for moving files into a pack (the pack must already exist).
-      Note this works for moving files to packs from the monolith or from other packs
+      Note this works for moving files to packs from the monolith or from other packs.
 
       Make sure there are no spaces between the comma-separated list of paths of directories.
     LONG_DESC

--- a/lib/packs/cli.rb
+++ b/lib/packs/cli.rb
@@ -39,10 +39,10 @@ module Packs
       exit_successfully
     end
 
-    POSIBLE_TYPES = T.let(%w[dependency privacy layer], T::Array[String])
+    POSSIBLE_TYPES = T.let(%w[dependency privacy layer], T::Array[String])
     desc 'list_top_violations type [ packs/your_pack ]', 'List the top violations of a specific type for packs/your_pack.'
     long_desc <<~LONG_DESC
-      Possible types are: #{POSIBLE_TYPES.join(', ')}.
+      Possible types are: #{POSSIBLE_TYPES.join(', ')}.
 
       Want to see who is depending on you? Not sure how your pack's code is being used in an unstated way? You can use this command to list the top dependency violations.
 
@@ -60,7 +60,7 @@ module Packs
       ).void
     end
     def list_top_violations(type, pack_name = nil)
-      raise StandardError, "Invalid type #{type}. Possible types are: #{POSIBLE_TYPES.join(', ')}" unless POSIBLE_TYPES.include?(type)
+      raise StandardError, "Invalid type #{type}. Possible types are: #{POSSIBLE_TYPES.join(', ')}" unless POSSIBLE_TYPES.include?(type)
 
       Packs.list_top_violations(
         type: type,
@@ -135,8 +135,8 @@ module Packs
     sig { params(pack_names: String).void }
     def get_info(*pack_names)
       selected_types = options[:types].to_s.downcase.split(',')
-      invalid_types = selected_types - POSIBLE_TYPES
-      raise StandardError, "Invalid type(s): #{invalid_types.join(', ')}. Possible types are: #{POSIBLE_TYPES.join(', ')}" unless invalid_types.empty?
+      invalid_types = selected_types - POSSIBLE_TYPES
+      raise StandardError, "Invalid type(s): #{invalid_types.join(', ')}. Possible types are: #{POSSIBLE_TYPES.join(', ')}" unless invalid_types.empty?
 
       Private.get_info(
         packs: parse_pack_names(pack_names),

--- a/lib/packs/private.rb
+++ b/lib/packs/private.rb
@@ -530,7 +530,7 @@ module Packs
     def self.bust_cache!
       Packs.config.bust_cache!
       # This comes explicitly after `Packs.config.bust_cache!` because
-      # otherwise `Packs.config` will attempt to reload the client configuratoin.
+      # otherwise `Packs.config` will attempt to reload the client configuration.
       @loaded_client_configuration = false
     end
 


### PR DESCRIPTION
## Summary
- Fix typo: rename `POSIBLE_TYPES` → `POSSIBLE_TYPES` constant in CLI (6 occurrences)
- Fix typo: `configuratoin` → `configuration` in comment
- Fix additional grammatical issues found in documentation

## Changes
- Commit 1: Fix confirmed typos found by `typos` tool
- Commit 2: Additional grammar/prose improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)